### PR TITLE
Fixup multiword definitions

### DIFF
--- a/lib/slackmos/commands/urban_dictionary.rb
+++ b/lib/slackmos/commands/urban_dictionary.rb
@@ -1,4 +1,4 @@
-require "cgi"
+require "uri"
 
 module Slackmos
   module Commands
@@ -17,7 +17,7 @@ module Slackmos
       def definitions
         response = client.get do |request|
           request.url callback_uri.path
-          request.params = { term: CGI.escape(command.command_text) }
+          request.params = { term: URI.escape(command.command_text) }
         end
 
         JSON.parse(response.body)["list"]

--- a/lib/slackmos/commands/urban_dictionary.rb
+++ b/lib/slackmos/commands/urban_dictionary.rb
@@ -1,5 +1,3 @@
-require "uri"
-
 module Slackmos
   module Commands
     # Help you understand slang
@@ -17,7 +15,7 @@ module Slackmos
       def definitions
         response = client.get do |request|
           request.url callback_uri.path
-          request.params = { term: URI.escape(command.command_text) }
+          request.params = { term: command.command_text }
         end
 
         JSON.parse(response.body)["list"]


### PR DESCRIPTION
Multiword definitions didn't work due to bad escaping. This fixes it.

/cc @thephw